### PR TITLE
Integrated prototype of launching submenu

### DIFF
--- a/src/main/java/units/shooter_developers/WinnerWindow.java
+++ b/src/main/java/units/shooter_developers/WinnerWindow.java
@@ -15,6 +15,7 @@ import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
 import javafx.application.Application;
 import javafx.stage.Stage;
+import units.shooter_developers.menu.GameMenu;
 
 public class WinnerWindow extends Application{
     WinnerScreenObject _content;

--- a/src/main/java/units/shooter_developers/menu/GameMenu.java
+++ b/src/main/java/units/shooter_developers/menu/GameMenu.java
@@ -53,15 +53,34 @@ public class GameMenu extends Menu{
         {
             item.setOnMouseReleased(event -> {
                 if (item.getName().equals("NEW GAME")) {
+                    //------------------------------------------------------------------------------------
+                    /*
+                    Submenu submenu_launch_game = new Submenu(this);
+                    submenu_launch_game.start(menu_stage);
+                    */
+
+                    /**    /\
+                     *     |
+                     *     |
+                     *     UNCOMMENT FOR HAVING ACCESS TO LAUNCHING SUBMENU
+                     *     ------------------------------------------------------------------------------
+                     *     UNCOMMENT FOR HAVING ACCESS TO SIMULATION (UP-TO-NOW SITUATION)
+                     *     |
+                     *     |
+                     *    \/
+                     */
+
+                    /***/
                     setGameInstance(new Simulation());
                     try {
                         menu_stage.close();
                         getGameInstance().start(getStage());
-                        //getStage().toFront();
                         getStage().setAlwaysOnTop(true);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
+                    /***/
+                    //----------------------------------------------------------------------------------------------
                 }
                 if (item.getName().equals("CONTINUE")) {
                     menu_stage.close();

--- a/src/main/java/units/shooter_developers/menu/Menu.java
+++ b/src/main/java/units/shooter_developers/menu/Menu.java
@@ -15,6 +15,7 @@ package units.shooter_developers.menu;
 import javafx.application.Application;
 import javafx.geometry.Pos;
 import javafx.geometry.Rectangle2D;
+import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
@@ -161,6 +162,28 @@ public abstract class Menu extends Application {
         for(var tag:selection_tags){ tag_list.add(tag); }
 
         getItemsBox().addSelectableItem(item_name, tag_list);
+    }
+
+    public void addGenericNode(Node generic_node){
+        _root.getChildren().add(generic_node);
+    }
+
+    public void removeTitle(){
+        Title title_object = (Title)_root.getChildren().stream()
+                .filter(e -> e instanceof Title)
+                .findFirst()
+                .orElse(null);
+
+        _root.getChildren().remove(title_object);
+    }
+
+    public void removeMenuBox(){
+        MenuBox menu_box = (MenuBox) _root.getChildren().stream()
+                .filter(e -> e instanceof MenuBox)
+                .findFirst()
+                .orElse(null);
+
+        _root.getChildren().remove(menu_box);
     }
 
     public void setTitle(String title){

--- a/src/main/java/units/shooter_developers/menu/Submenu.java
+++ b/src/main/java/units/shooter_developers/menu/Submenu.java
@@ -3,55 +3,69 @@ package units.shooter_developers.menu;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Pos;
+import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
 
-public class Submenu extends VBox {
-
-    double _width, _height;
-    Player_selection_menu P_menu;
-    Map_selection_menu P_map;
-
-    Submenu(double width, double height)
-    {
-        this._width = width;
-        this._height = height;
-
-        this.setPrefSize(width,height);
-
-         P_menu = new Player_selection_menu(_width,_height/2);
-         P_map =  new Map_selection_menu( _width*.8,_height/2);
-
-         P_map.setAlignment(Pos.CENTER);
-
-
-         // La parte che segue sarà cambiata per maggiore modularità
-
-        HBox H = new HBox(P_map);
-
-
-        Button LAUNCH_BUTTON = new Button();
-        LAUNCH_BUTTON.setText("LAUNCH SIMULATION");
-        H.getChildren().add(LAUNCH_BUTTON);
-        H.setAlignment(Pos.CENTER_LEFT);
-
-
-        LAUNCH_BUTTON.disableProperty().bind(P_map.all_setProperty().or(P_menu.all_setProperty()));
-
-
-        LAUNCH_BUTTON.setOnAction((EventHandler<ActionEvent>) event ->
-                System.out.println(P_menu.get_players_data() +""+ P_map.get_map_data()));
-
-        getChildren().add(P_menu);
-        getChildren().add(H);
-
-
-
-
-
+public class Submenu extends Menu{
+    Submenu(Menu other_menu){
+        super(other_menu);
     }
 
+    public void start(Stage stage){
+        setStage(stage);
+
+        SubmenuObject content = new SubmenuObject(getMenuWidth(), getMenuHeight());
+
+        addGenericNode(content);
+        removeTitle();
+        removeMenuBox();
+        Scene scene = new Scene(getRoot());
+        getStage().setScene(scene);
+        getStage().close();
+        getStage().show();
+        getStage().setAlwaysOnTop(true);
+    }
+
+    private class SubmenuObject extends VBox {
+
+        double _width, _height;
+        Player_selection_menu P_menu;
+        Map_selection_menu P_map;
+
+        SubmenuObject(double width, double height) {
+            this._width = width;
+            this._height = height;
+
+            this.setPrefSize(width, height);
+
+            P_menu = new Player_selection_menu(_width, _height / 2);
+            P_map = new Map_selection_menu(_width * .8, _height / 2);
+
+            P_map.setAlignment(Pos.CENTER);
 
 
+            // La parte che segue sarà cambiata per maggiore modularità
+
+            HBox H = new HBox(P_map);
+
+
+            Button LAUNCH_BUTTON = new Button();
+            LAUNCH_BUTTON.setText("LAUNCH SIMULATION");
+            H.getChildren().add(LAUNCH_BUTTON);
+            H.setAlignment(Pos.CENTER_LEFT);
+
+
+            LAUNCH_BUTTON.disableProperty().bind(P_map.all_setProperty().or(P_menu.all_setProperty()));
+
+
+            LAUNCH_BUTTON.setOnAction((EventHandler<ActionEvent>) event ->
+                    System.out.println(P_menu.get_players_data() + "" + P_map.get_map_data()));
+
+            getChildren().add(P_menu);
+            getChildren().add(H);
+        }
+    }
 }


### PR DESCRIPTION
Integrated @paoloearth prototype of submenu. In order to have access to it, it is necessary to uncomment the indicated code within GameMenu.java (near the line 56). Note that this submenu is not connected yet with the simulation, thus, in order to launch the game it is necessary to use the old implementation (without submenu). 

Added a pair of useful functions to Menu API (removeTitle and removeMenuBox).